### PR TITLE
- Removed dependency on Requests lib -> replace by urllib

### DIFF
--- a/radarr-unmonitor.py
+++ b/radarr-unmonitor.py
@@ -2,12 +2,13 @@
 ###################################
 # Unmonitor Script for Radarr
 # Author : MadSurfer
-# Date : 23.08.2021
-# Version : 0.4
+# Date : 01.11.2021
+# Version : 0.7b
 # Description : Automatically unmonitor episde on "Import"
 ###################################
 
-import logging, requests, json
+import logging, json, ssl
+from urllib.request import Request, urlopen
 
 from os import environ, path
 
@@ -16,19 +17,23 @@ RADARR_HOST = ""
 REQ_HEADERS = {'X-Api-Key': RADARR_API_KEY, 'Content-Type': 'application/json'}
 
 def getMovie(movieID):
-    apireq = "{0}/api/v3/movie/{1}"
-    rep = requests.get(apireq.format(RADARR_HOST, movieID), headers=REQ_HEADERS)
-    return rep.json()
+    apireq = "{0}/api/v3/movie/{1}".format(RADARR_HOST, movieID)
+    ssl._create_default_https_context = ssl._create_unverified_context
+    request = Request(method='GET', headers=REQ_HEADERS, url=apireq)
+    rep = urlopen(request)
+    MovieData = json.load(rep)
+    return MovieData
 
 def setMonitoring(movieID, MonitoringStatus):
-    apireq = "{0}/api/v3/movie/{1}?moveFiles=false"
+    apireq = "{0}/api/v3/movie/{1}?moveFiles=false".format(RADARR_HOST, movieID)
     movieItem = getMovie(movieID)
     movieItem["monitored"] = MonitoringStatus
-    rep = requests.put(apireq.format(RADARR_HOST, movieID), data=json.dumps(movieItem), headers=REQ_HEADERS)
+    request = Request(method='PUT', headers=REQ_HEADERS, data=json.dumps(movieItem).encode('utf-8'), url=apireq)
+    rep = urlopen(request)
 
 EventType = environ.get('sonarr_eventtype')
 if EventType == 'Test':
-    logging.info("Episode Unmonitor script testing")
+    logging.info("Movie Unmonitor script testing")
 else:
     movieId = environ.get("radarr_movie_id")
     if movieId:

--- a/sonarr-unmonitor.py
+++ b/sonarr-unmonitor.py
@@ -2,13 +2,13 @@
 ###################################
 # Unmonitor Script for Sonarr
 # Author : MadSurfer
-# Date : 22.08.2021
-# Version : 0.4
+# Date : 01.11.2021
+# Version : 0.7b
 # Description : Automatically unmonitor episde on "Import"
 ###################################
 
-import logging
-import requests, json
+import logging, json, ssl
+from urllib.request import Request, urlopen
 
 from os import environ, path
 
@@ -17,21 +17,19 @@ SONARR_HOST = ""
 REQ_HEADERS = {'X-Api-Key': SONARR_API_KEY, 'Content-Type': 'application/json'}
 
 def getEpisode(episodeID):
-    apireq = "{0}/api/episode/{1}"
-    rep = requests.get(apireq.format(SONARR_HOST, episodeID, SONARR_API_KEY), headers=REQ_HEADERS)
-    return rep.json()
+    apireq = "{0}/api/episode/{1}".format(SONARR_HOST, episodeID)
+    ssl._create_default_https_context = ssl._create_unverified_context
+    request = Request(method='GET', headers=REQ_HEADERS, url=apireq)
+    rep = urlopen(request)
+    epData = json.load(rep)
+    return epData
 
 def setMonitoring(episodeID, MonitorStatus):
-    apireq = "{0}/api/episode/{1}"
+    apireq = "{0}/api/episode/{1}".format(SONARR_HOST, episodeID)
     episodeInfos = getEpisode(episodeID)
     episodeInfos["monitored"] = MonitorStatus
-    payload = {'json_payload': json.dumps(episodeInfos)}
-    rep = requests.put(apireq.format(SONARR_HOST, episodeID), 
-        data=json.dumps(episodeInfos), 
-        headers=REQ_HEADERS)
-    if rep.status_code != 202:
-        print("HTTP {0}".format(rep.status_code))
-        print(rep.json())
+    request = Request(method='PUT', headers=REQ_HEADERS, data=json.dumps(episodeInfos).encode('utf-8'), url=apireq)
+    rep = urlopen(request)
 
 EventType = environ.get('sonarr_eventtype')
 if EventType == 'Test':
@@ -42,3 +40,4 @@ else:
         setMonitoring(epId, False)
         logMsg = "Sonarr post-import: Episode ID = {0}"
         logging.info(logMsg.format(epId))
+


### PR DESCRIPTION
- New 0.7b release which get rid of requests libraries for more portability
- Library requests is replaced by urllib (standard python 3.x)
- this release DOES NOT VALIDATE SSL certificate