### PR TITLE
Modernize and harden Radarr/Sonarr unmonitor scripts (v1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 testing/*
 uenv/*
 venv/*
+__pycache__/
+*.pyc

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,161 @@
+# PRD — Arr-Unmonitor Modernization & Hardening
+
+**Status:** Draft
+**Date:** 2026-06-04
+**Owner:** dcampillo
+**Current version:** 0.9 (Nov 2021)
+**Target version:** 1.0
+
+---
+
+## 1. Background
+
+Arr-Unmonitor is a pair of Python custom-script connectors that automatically
+unmonitor a movie (Radarr) or episode (Sonarr) after a download is imported.
+They are registered in Radarr/Sonarr under **Settings → Connect → Custom Scripts**
+with the "On Import" trigger, and receive their input through environment
+variables set by the *arr app.
+
+The scripts were last released in November 2021 (v0.9). Since then Sonarr has
+moved to v3/v4 and **removed the unversioned `/api/...` endpoints** the Sonarr
+script depends on. As a result the Sonarr script no longer works against current
+installs, and several latent bugs and rough edges have accumulated.
+
+## 2. Goals
+
+1. **Make the Sonarr script work on current Sonarr (v3/v4).**
+2. **Fix the multi-episode import bug** so multi-episode files unmonitor correctly.
+3. **Fix correctness bugs and typos** in both scripts.
+4. **Improve robustness** (timeouts, clearer errors, correct exit codes).
+5. **Keep the zero-dependency, single-file, env-var-driven design** — it must
+   still run as a Custom Script with stock Python 3.
+
+## 3. Non-Goals
+
+- No rewrite into a package, daemon, or service.
+- No third-party dependencies (must run with the Python stdlib only).
+- No GUI / web interface.
+- No change to the *arr-side setup workflow (still a Custom Script on "On Import").
+
+## 4. Current State & Problems
+
+### 4.1 Sonarr script (`sonarr-unmonitor.py`)
+
+| # | Severity | Problem |
+|---|----------|---------|
+| S1 | **Blocker** | Uses removed v2 endpoint `/api/episode/{id}`. Current Sonarr requires `/api/v3/episode/...`. Script fails (404 / URLError) on modern Sonarr. |
+| S2 | **High** | `sonarr_episodefile_episodeids` can be a **comma-separated list** on multi-episode files. The code passes the raw string as a single ID, so multi-episode imports break (and even single IDs hit the wrong endpoint). |
+| S3 | Medium | Generic `except Exception` writes `"Unknow Error RRRRRRRRRR"` (typo, unhelpful) and does **not** exit non-zero, so failures look like success to Sonarr. |
+| S4 | Low | Config "Test" event validates API key and port but not host. |
+| S5 | Low | Unused imports: `logging`, `re`, `path`. Typos in comments ("episde"). |
+
+### 4.2 Radarr script (`radarr-unmonitor.py`)
+
+| # | Severity | Problem |
+|---|----------|---------|
+| R1 | **Functional** ✅ | Already on v3 (`/api/v3/movie/{id}`) — GET-then-PUT flow is still valid. |
+| R2 | Medium | Success message says `EpisodeID:{movieid} - Unmonitored` — copy-paste from Sonarr; should say MovieID. Misleading logs. |
+| R3 | Medium | Same swallowed-`Exception` issue as S3 (no non-zero exit, "Unknow Error" typo). |
+| R4 | Low | Unused imports: `logging`, `re`, `path`. |
+
+### 4.3 Shared issues
+
+| # | Severity | Problem |
+|---|----------|---------|
+| C1 | Medium | No request **timeout** on `urlopen`; a hung *arr app can hang the import callback. |
+| C2 | Low | SSL bypass is done via global `ssl._create_default_https_context` mutation inside the GET helper; works but is implicit and only set on the GET path. Prefer an explicit `ssl.SSLContext` passed to `urlopen`. |
+| C3 | Low | Secrets (`ARR_API_KEY`) are hardcoded in the file. Optionally allow override via environment variable so the key need not live in the script. |
+| C4 | Low | Significant duplication between the two scripts. Out of scope to merge, but config/typo fixes should be applied consistently to both. |
+
+## 5. Requirements
+
+### 5.1 Functional
+
+- **FR1 (S1):** The Sonarr script MUST call the versioned endpoint
+  `PUT /api/v3/episode/monitor` with body
+  `{"episodeIds": [<int>...], "monitored": false}`.
+  This single call replaces the GET-then-PUT flow and works on Sonarr v3 and v4.
+- **FR2 (S2):** The Sonarr script MUST parse `sonarr_episodefile_episodeids` as a
+  comma-separated list, convert each entry to an int, and unmonitor **all** of them
+  in one `/episode/monitor` call.
+- **FR3 (R2):** The Radarr success message MUST report `MovieID`, not `EpisodeID`.
+- **FR4 (S3/R3):** On any unhandled error the scripts MUST write a clear message
+  to stderr **and exit with a non-zero status** so the *arr app surfaces the failure.
+- **FR5:** The "Test" event behavior MUST be preserved (validate config, return
+  success/failure) so the in-app "Test" button still works. Optionally also
+  validate that `ARR_HOST` is set (S4).
+
+### 5.2 Non-Functional
+
+- **NFR1 (C1):** All HTTP calls MUST use an explicit timeout (e.g. 30s).
+- **NFR2:** Scripts MUST remain single-file, stdlib-only, Python 3.8+ compatible.
+- **NFR3 (C2):** SSL verification bypass MUST be explicit and applied to every
+  request (GET and PUT), not just one path.
+- **NFR4 (C3, optional):** `ARR_API_KEY`, `ARR_HOST`, `ARR_PORT` MAY be overridable
+  via environment variables, falling back to the in-file constants.
+
+### 5.3 Cleanup
+
+- **CR1 (S5/R4):** Remove unused imports (`logging`, `re`, `path`).
+- **CR2:** Fix typos in code, messages, and README ("Unmomitor", "episde",
+  "Unknow", "EpisodeID" in Radarr).
+- **CR3:** Bump version to **1.0** in both script headers and update the README
+  (Sonarr now uses `/api/v3`, note Sonarr v4 support).
+
+## 6. Proposed Approach (high level)
+
+**Sonarr script:**
+1. Build base URL `http(s)://{host}:{port}/api/v3`.
+2. Read `sonarr_episodefile_episodeids`, split on `,`, strip, cast to `int`.
+3. `PUT /api/v3/episode/monitor` with `{"episodeIds": [...], "monitored": false}`.
+4. Wrap in try/except with explicit stderr message + `sys.exit(1)` on failure.
+
+**Radarr script:**
+1. Keep the v3 GET-then-PUT flow (no bulk endpoint needed for a single movie).
+2. Fix the success message to say MovieID.
+3. Apply the shared error-handling/timeout/SSL/import cleanups.
+
+**Both:** add `timeout=` to `urlopen`, explicit `ssl.SSLContext`, remove unused
+imports, fix typos, bump to v1.0.
+
+## 7. Testing & Acceptance
+
+- **A1:** With a real or mocked Sonarr v4, importing a **single-episode** file
+  unmonitors that episode; the script exits 0.
+- **A2:** Importing a **multi-episode** file (e.g. `"101,102"`) unmonitors **all**
+  listed episodes in one request.
+- **A3:** A bad host/API key produces a clear stderr message and a **non-zero**
+  exit code (verifiable via the in-app "Test" and a forced-failure run).
+- **A4:** Radarr import unmonitors the movie and logs `MovieID:<id>`.
+- **A5:** Both scripts run under Python 3.8 with no extra packages installed.
+- **A6:** The `testing/setenv.py` helper continues to provide sample env vars for
+  local runs (extend with a multi-id example like `"101,102"`).
+
+> Note: live testing requires running Radarr/Sonarr instances, which the CI/dev
+> environment may not have. Where a live instance is unavailable, validate via a
+> local mock/stub of the HTTP endpoint and by asserting the constructed
+> request (URL, method, body).
+
+## 8. Risks & Open Questions
+
+- **Q1:** Sonarr API key for the `/api/v3` endpoints is unchanged from v2 — confirm
+  against the user's actual install version (v3 vs v4).
+- **Q2:** Should env-var overrides (NFR4) be in scope for 1.0, or deferred? Keeps
+  secrets out of the script but adds surface area.
+- **Q3:** Is merging the two scripts into one shared module desired later, or keep
+  them intentionally standalone for drop-in simplicity? (Currently: keep separate.)
+
+---
+
+### Summary of work items
+
+| ID | Item | Priority |
+|----|------|----------|
+| FR1 | Sonarr → `/api/v3/episode/monitor` | P0 |
+| FR2 | Parse multi-episode ID list | P0 |
+| FR4 | Non-zero exit + clear errors (both) | P1 |
+| FR3 | Radarr MovieID log fix | P1 |
+| NFR1 | Request timeouts | P1 |
+| NFR3 | Explicit SSL handling | P2 |
+| CR1/CR2/CR3 | Imports, typos, version + README | P2 |
+| NFR4 | Env-var config override (optional) | P3 |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 # Arr-Unmonitor
-Sonarr/Radarr custom scripts to unmomitor episodes or movies after import.
+Sonarr/Radarr custom scripts to unmonitor episodes or movies after import.
+
+> **v1.0** — The Sonarr script now uses the Sonarr API **v3** endpoint
+> (`/api/v3/episode/monitor`) and works with **Sonarr v3 and v4**. It also
+> correctly handles multi-episode imports. The Radarr script uses Radarr API v3.
 
 ## Requirements
 - Python 3.x is recommended
@@ -14,9 +18,14 @@ Update each script accordingly:
  3. Settings to be set in the script:
 	 1. ARR_API_KEY = ""
 	 2. ARR_HOST = "" # example : my.domain.info
-	 3. ARR_PORT = "" # default Radarr port = 7878
+	 3. ARR_PORT = "" # default Radarr port = 7878 / default Sonarr port = 8989
 	 5. ARR_USE_SSL = False # Default = False, if set to True, configure the ARR_PORT appropriately
 	 6. ARR_CHECK_SSL = True # Default = True, ARR will check the validity of the SSL Certificate
+
+> **Tip:** Instead of editing the script, you can override `ARR_API_KEY`,
+> `ARR_HOST` and `ARR_PORT` via environment variables of the same name — handy
+> for keeping the API key out of the file. The environment value takes
+> precedence over the in-file value.
 
 
 ## Sonarr / Radarr configuration

--- a/radarr-unmonitor.py
+++ b/radarr-unmonitor.py
@@ -3,64 +3,84 @@
 # Unmonitor Script for Radarr
 # Author : MadSurfer
 # Date : 06.11.2021
-# Version : 0.9
+# Version : 1.0
 # Description : Automatically unmonitor movie on "Import"
-# Release note: Import changes in the configuration of the script!!!
+# Release note: Uses Radarr API v3. See README / CHANGELOG.
 ###################################
 
-import logging, json, ssl, re, sys
+import json, ssl, sys
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
+from os import environ
 
-from os import environ, path
+# --- Configuration --------------------------------------------------------
+# Edit the values below, or override any of them via environment variables
+# of the same name (the environment value takes precedence).
+ARR_API_KEY = ""  # set your API key here (or via the ARR_API_KEY env var)
+ARR_HOST = ""     # example : my.domain.info (or ARR_HOST env var)
+ARR_PORT = ""     # default Radarr port = 7878 (or ARR_PORT env var)
+ARR_USE_SSL = False   # Default = False, if set to True, configure ARR_PORT appropriately
+ARR_CHECK_SSL = True  # Default = True, verify the validity of the SSL certificate
 
-ARR_API_KEY = ""
-ARR_HOST = "" # example : my.domain.info
-ARR_PORT = "" # default Radarr port = 7878
+# Environment variables take precedence over the in-file values above
+ARR_API_KEY = environ.get("ARR_API_KEY", ARR_API_KEY)
+ARR_HOST = environ.get("ARR_HOST", ARR_HOST)
+ARR_PORT = environ.get("ARR_PORT", ARR_PORT)
+
 REQ_HEADERS = {'X-Api-Key': ARR_API_KEY, 'Content-Type': 'application/json'}
-ARR_USE_SSL = False # Default = False, if set to True, configure the ARR_PORT appropriately
-ARR_CHECK_SSL = True # Default = True, ARR will check the validity of the SSL Certificate
+REQ_TIMEOUT = 30  # seconds
+# --------------------------------------------------------------------------
+
+
+def getSslContext():
+    """Return an SSLContext with verification disabled when requested, else None."""
+    if ARR_USE_SSL and not ARR_CHECK_SSL:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    return None
+
+
+def buildUrl(pathAndQuery):
+    scheme = "https" if ARR_USE_SSL else "http"
+    return "{scheme}://{host}:{port}/api/v3/{path}".format(
+        scheme=scheme, host=ARR_HOST, port=ARR_PORT, path=pathAndQuery)
+
 
 def getMovie(movieID):
-    if ARR_USE_SSL:
-        apireq = "https://{host}:{port}/api/v3/movie/{movieid}".format(host=ARR_HOST, port=ARR_PORT, movieid=movieID)
-        if ARR_CHECK_SSL == False:
-            ssl._create_default_https_context = ssl._create_unverified_context
-    else:
-        apireq = "http://{host}:{port}/api/v3/movie/{movieid}".format(host=ARR_HOST, port=ARR_PORT, movieid=movieID)
+    request = Request(method='GET', headers=REQ_HEADERS,
+                      url=buildUrl("movie/{movieid}".format(movieid=movieID)))
+    rep = urlopen(request, timeout=REQ_TIMEOUT, context=getSslContext())
+    return json.load(rep)
 
-    request = Request(method='GET', headers=REQ_HEADERS, url=apireq)
-    
-    rep = urlopen(request)
-    MovieData = json.load(rep)
-    return MovieData
 
 def setMonitoring(movieID, MonitoringStatus):
-    if ARR_USE_SSL:
-        apireq = "https://{host}:{port}/api/v3/movie/{movieid}?moveFiles=false".format(host=ARR_HOST, port=ARR_PORT, movieid=movieID)
-    else:
-        apireq = "http://{host}:{port}/api/v3/movie/{movieid}?moveFiles=false".format(host=ARR_HOST, port=ARR_PORT, movieid=movieID)
-
     try:
         movieItem = getMovie(movieID)
         if movieItem:
             movieItem["monitored"] = MonitoringStatus
-            request = Request(method='PUT', headers=REQ_HEADERS, data=json.dumps(movieItem).encode('utf-8'), url=apireq)
-            rep = urlopen(request)
-            sys.stdout.write("RADARR_UNMONITOR: EpisodeID:{movieid} - Unmonitored".format(movieid=movieID))
+            request = Request(method='PUT', headers=REQ_HEADERS,
+                              data=json.dumps(movieItem).encode('utf-8'),
+                              url=buildUrl("movie/{movieid}?moveFiles=false".format(movieid=movieID)))
+            urlopen(request, timeout=REQ_TIMEOUT, context=getSslContext())
+            sys.stdout.write("RADARR_UNMONITOR: MovieID:{movieid} - Unmonitored".format(movieid=movieID))
         else:
-            print("Episode not found")
+            sys.stderr.write("RADARR_UNMONITOR: MovieID:{movieid} - Movie not found".format(movieid=movieID))
+            sys.exit(1)
 
     except HTTPError as err:
-        sys.stderr.write("RADARR_UNMONITOR: EpisodeID:{movieid} - HTTP{httpcode} - {reason}".format(movieid=movieID, httpcode=err.code, reason=err.reason))
+        sys.stderr.write("RADARR_UNMONITOR: MovieID:{movieid} - HTTP{httpcode} - {reason}".format(movieid=movieID, httpcode=err.code, reason=err.reason))
         sys.exit(1)
 
     except URLError as err:
-        sys.stderr.write("RADARR_UNMONITOR: EpisodeID:{movieid} - Error: {reason} | Check script configuration ARR_HOST setting".format(movieid=movieID, reason=err.reason))
+        sys.stderr.write("RADARR_UNMONITOR: MovieID:{movieid} - Error: {reason} | Check script configuration ARR_HOST setting".format(movieid=movieID, reason=err.reason))
         sys.exit(1)
 
     except Exception as err:
-        sys.stderr.write("RADARR_UNMONITOR: Unknow Error RRRRRRRRRR")
+        sys.stderr.write("RADARR_UNMONITOR: MovieID:{movieid} - Unknown error: {err}".format(movieid=movieID, err=err))
+        sys.exit(1)
+
 
 def main():
     EventType = environ.get('radarr_eventtype')
@@ -70,6 +90,12 @@ def main():
             print("CONFIG_CHECK: API key is present")
         else:
             sys.stderr.write("CONFIG_CHECK API_KEY: API Key '' is a NOT VALID API KEY!")
+            sys.exit("CONFIG_CHECK_ERROR")
+
+        if ARR_HOST != "":
+            print("CONFIG_CHECK: HOST is set!")
+        else:
+            sys.stderr.write("CONFIG_CHECK ERROR ARR_HOST: ARR_HOST '' is a NOT VALID HOST!")
             sys.exit("CONFIG_CHECK_ERROR")
 
         if ARR_PORT != "":
@@ -83,6 +109,7 @@ def main():
         if movieId:
             setMonitoring(movieId, False)
             print("Movie ID {movieid} unmonitored!".format(movieid=movieId))
+
 
 if __name__ == "__main__":
     main()

--- a/radarr-unmonitor.py
+++ b/radarr-unmonitor.py
@@ -5,7 +5,7 @@
 # Date : 06.11.2021
 # Version : 1.0
 # Description : Automatically unmonitor movie on "Import"
-# Release note: Uses Radarr API v3. See README / CHANGELOG.
+# Release note: Uses Radarr API v3. See README.
 ###################################
 
 import json, ssl, sys
@@ -14,8 +14,9 @@ from urllib.error import HTTPError, URLError
 from os import environ
 
 # --- Configuration --------------------------------------------------------
-# Edit the values below, or override any of them via environment variables
-# of the same name (the environment value takes precedence).
+# Edit the values below. ARR_API_KEY, ARR_HOST and ARR_PORT can also be
+# overridden via environment variables of the same name (the environment value
+# takes precedence). ARR_USE_SSL / ARR_CHECK_SSL are set here only.
 ARR_API_KEY = ""  # set your API key here (or via the ARR_API_KEY env var)
 ARR_HOST = ""     # example : my.domain.info (or ARR_HOST env var)
 ARR_PORT = ""     # default Radarr port = 7878 (or ARR_PORT env var)

--- a/sonarr-unmonitor.py
+++ b/sonarr-unmonitor.py
@@ -3,66 +3,84 @@
 # Unmonitor Script for Sonarr
 # Author : MadSurfer
 # Date : 06.11.2021
-# Version : 0.9
-# Description : Automatically unmonitor episde on "Import"
-# Release note: Import changes in the configuration of the script!!!
+# Version : 1.0
+# Description : Automatically unmonitor episode(s) on "Import"
+# Release note: Uses Sonarr API v3 (works with Sonarr v3 and v4). See README.
 ###################################
 
-import logging, json, ssl, re, sys
+import json, ssl, sys
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
-from os import environ, path
+from os import environ
 
-ARR_API_KEY = ""
-ARR_HOST = ""  # example : my.domain.info
-ARR_PORT = "" # default Radarr port = 8989
+# --- Configuration --------------------------------------------------------
+# Edit the values below, or override any of them via environment variables
+# of the same name (the environment value takes precedence).
+ARR_API_KEY = ""  # set your API key here (or via the ARR_API_KEY env var)
+ARR_HOST = ""     # example : my.domain.info (or ARR_HOST env var)
+ARR_PORT = ""     # default Sonarr port = 8989 (or ARR_PORT env var)
+ARR_USE_SSL = False   # Default = False, if set to True, configure ARR_PORT appropriately
+ARR_CHECK_SSL = True  # Default = True, verify the validity of the SSL certificate
+
+# Environment variables take precedence over the in-file values above
+ARR_API_KEY = environ.get("ARR_API_KEY", ARR_API_KEY)
+ARR_HOST = environ.get("ARR_HOST", ARR_HOST)
+ARR_PORT = environ.get("ARR_PORT", ARR_PORT)
+
 REQ_HEADERS = {'X-Api-Key': ARR_API_KEY, 'Content-Type': 'application/json'}
-ARR_USE_SSL = False # Default = False, if set to True, configure the ARR_PORT appropriately
-ARR_CHECK_SSL = True # Default = True, ARR will check the validity of the SSL Certificate
+REQ_TIMEOUT = 30  # seconds
+# --------------------------------------------------------------------------
 
-def getEpisode(episodeID):
-    
-    if ARR_USE_SSL:
-        apireq = "https://{host}:{port}/api/episode/{epid}".format(host=ARR_HOST, port=ARR_PORT, epid=episodeID)
-        if ARR_CHECK_SSL == False:
-            ssl._create_default_https_context = ssl._create_unverified_context
-    else:
-        apireq = "http://{host}:{port}/api/episode/{epid}".format(host=ARR_HOST, port=ARR_PORT, epid=episodeID)
 
-    request = Request(method='GET', headers=REQ_HEADERS, url=apireq)
-    rep = urlopen(request)
-    epData = json.load(rep)
-    return epData
+def getSslContext():
+    """Return an SSLContext with verification disabled when requested, else None."""
+    if ARR_USE_SSL and not ARR_CHECK_SSL:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    return None
 
-def setMonitoring(episodeID, MonitorStatus):
-    if ARR_USE_SSL:
-        apireq = "https://{host}:{port}/api/episode/{epid}".format(host=ARR_HOST, port=ARR_PORT, epid=episodeID)
-    else:
-        apireq = "http://{host}:{port}/api/episode/{epid}".format(host=ARR_HOST, port=ARR_PORT, epid=episodeID)
-    
+
+def buildUrl(pathAndQuery):
+    scheme = "https" if ARR_USE_SSL else "http"
+    return "{scheme}://{host}:{port}/api/v3/{path}".format(
+        scheme=scheme, host=ARR_HOST, port=ARR_PORT, path=pathAndQuery)
+
+
+def parseEpisodeIds(raw):
+    """Sonarr can pass a comma-separated list of episode IDs for multi-episode files."""
+    ids = []
+    for part in raw.split(","):
+        part = part.strip()
+        if part:
+            ids.append(int(part))
+    return ids
+
+
+def setMonitoring(episodeIDs, MonitorStatus):
+    payload = {"episodeIds": episodeIDs, "monitored": MonitorStatus}
     try:
-        episodeInfos = getEpisode(episodeID)
-        if episodeInfos:
-            episodeInfos["monitored"] = MonitorStatus
-            request = Request(method='PUT', headers=REQ_HEADERS, data=json.dumps(episodeInfos).encode('utf-8'), url=apireq)
-            rep = urlopen(request)
-            sys.stdout.write("SONARR_UNMONITOR: EpisodeID:{epid} - Unmonitored".format(epid=episodeID))
-        else:
-            print("Episode not found")
+        request = Request(method='PUT', headers=REQ_HEADERS,
+                          data=json.dumps(payload).encode('utf-8'),
+                          url=buildUrl("episode/monitor"))
+        urlopen(request, timeout=REQ_TIMEOUT, context=getSslContext())
+        sys.stdout.write("SONARR_UNMONITOR: EpisodeIDs:{epids} - Unmonitored".format(epids=episodeIDs))
 
     except HTTPError as err:
-        sys.stderr.write("SONARR_UNMONITOR: EpisodeID:{episodeID} - HTTP{httpcode} - {reason}".format(episodeID=episodeID, httpcode=err.code, reason=err.reason))
+        sys.stderr.write("SONARR_UNMONITOR: EpisodeIDs:{epids} - HTTP{httpcode} - {reason}".format(epids=episodeIDs, httpcode=err.code, reason=err.reason))
         sys.exit(1)
 
     except URLError as err:
-        sys.stderr.write("SONARR_UNMONITOR: EpisodeID:{episodeID} - Error: {reason} | Check script configuration ARR_HOST setting".format(episodeID=episodeID, reason=err.reason))
+        sys.stderr.write("SONARR_UNMONITOR: EpisodeIDs:{epids} - Error: {reason} | Check script configuration ARR_HOST setting".format(epids=episodeIDs, reason=err.reason))
         sys.exit(1)
 
     except Exception as err:
-        sys.stderr.write("SONARR_UNMONITOR: Unknow Error RRRRRRRRRR")
+        sys.stderr.write("SONARR_UNMONITOR: EpisodeIDs:{epids} - Unknown error: {err}".format(epids=episodeIDs, err=err))
+        sys.exit(1)
+
 
 def main():
-
     EventType = environ.get('sonarr_eventtype')
     if EventType == 'Test':
         print("Checking config")
@@ -72,6 +90,12 @@ def main():
             sys.stderr.write("CONFIG_CHECK API_KEY: API Key '' is a NOT VALID API KEY!")
             sys.exit("CONFIG_CHECK_ERROR")
 
+        if ARR_HOST != "":
+            print("CONFIG_CHECK: HOST is set!")
+        else:
+            sys.stderr.write("CONFIG_CHECK ERROR ARR_HOST: ARR_HOST '' is a NOT VALID HOST!")
+            sys.exit("CONFIG_CHECK_ERROR")
+
         if ARR_PORT != "":
             print("CONFIG_CHECK: PORT is set!")
         else:
@@ -79,10 +103,13 @@ def main():
             sys.exit("CONFIG_CHECK_ERROR")
 
     else:
-        epId = environ.get('sonarr_episodefile_episodeids')
-        if epId:
-            setMonitoring(epId, False)
-            print("Sonarr post-import: Episode ID = {episodeid}".format(episodeid=epId))
+        rawIds = environ.get('sonarr_episodefile_episodeids')
+        if rawIds:
+            episodeIds = parseEpisodeIds(rawIds)
+            if episodeIds:
+                setMonitoring(episodeIds, False)
+                print("Sonarr post-import: Episode IDs = {epids} unmonitored!".format(epids=episodeIds))
+
 
 if __name__ == "__main__":
     main()

--- a/sonarr-unmonitor.py
+++ b/sonarr-unmonitor.py
@@ -14,8 +14,9 @@ from urllib.error import HTTPError, URLError
 from os import environ
 
 # --- Configuration --------------------------------------------------------
-# Edit the values below, or override any of them via environment variables
-# of the same name (the environment value takes precedence).
+# Edit the values below. ARR_API_KEY, ARR_HOST and ARR_PORT can also be
+# overridden via environment variables of the same name (the environment value
+# takes precedence). ARR_USE_SSL / ARR_CHECK_SSL are set here only.
 ARR_API_KEY = ""  # set your API key here (or via the ARR_API_KEY env var)
 ARR_HOST = ""     # example : my.domain.info (or ARR_HOST env var)
 ARR_PORT = ""     # default Sonarr port = 8989 (or ARR_PORT env var)
@@ -105,7 +106,11 @@ def main():
     else:
         rawIds = environ.get('sonarr_episodefile_episodeids')
         if rawIds:
-            episodeIds = parseEpisodeIds(rawIds)
+            try:
+                episodeIds = parseEpisodeIds(rawIds)
+            except ValueError as err:
+                sys.stderr.write("SONARR_UNMONITOR: Invalid episode id list '{raw}': {err}".format(raw=rawIds, err=err))
+                sys.exit(1)
             if episodeIds:
                 setMonitoring(episodeIds, False)
                 print("Sonarr post-import: Episode IDs = {epids} unmonitored!".format(epids=episodeIds))

--- a/testing/setenv.py
+++ b/testing/setenv.py
@@ -1,6 +1,11 @@
 #!/usr/bin/python3
 import os
 
+# Single-episode import
 os.environ["sonarr_episodefile_episodeids"] = "11898"
-os.environ["radarr_movie_id"] ="1254"
 
+# Multi-episode import: Sonarr passes a comma-separated list of episode ids.
+# Swap the line above for this one to exercise the multi-episode code path.
+# os.environ["sonarr_episodefile_episodeids"] = "101,102"
+
+os.environ["radarr_movie_id"] = "1254"


### PR DESCRIPTION
## Summary

Modernizes both unmonitor scripts and fixes the latent bugs captured in the PRD and issues #7–#13. The headline fix: the **Sonarr script now works on current Sonarr (v3/v4)** — it previously called the removed v2 endpoint `/api/episode/{id}` and broke on multi-episode files.

Design constraints preserved: single-file, **stdlib-only**, Python 3.8+, drop-in as a Custom Script on "On Import".

## Changes (by issue)

- **#7 (P0)** — Sonarr migrated to `PUT /api/v3/episode/monitor` with body `{"episodeIds":[...], "monitored":false}`. `sonarr_episodefile_episodeids` is now parsed as a comma-separated list, so multi-episode imports unmonitor **all** episodes in one request.
- **#8 (P1)** — Both scripts now write a clear stderr message and `exit(1)` on failure (previously the generic handler printed "Unknow Error" and exited 0, so failures looked like success).
- **#9 (P1)** — Radarr success log now reports `MovieID` instead of the copy-pasted `EpisodeID`.
- **#10 (P1)** — All HTTP calls use a 30s timeout.
- **#11 (P2)** — SSL verification bypass uses an explicit `ssl.SSLContext` passed to every request (GET and PUT), instead of mutating global `ssl` state on the GET path only.
- **#12 (P2)** — Removed unused imports (`logging`, `re`, `path`), fixed typos, bumped headers to **v1.0**, added `ARR_HOST` validation to the Test event, and updated the README.
- **#13 (P3)** — `ARR_API_KEY` / `ARR_HOST` / `ARR_PORT` can be overridden via environment variables, falling back to the in-file constants (keeps the API key out of the file).

Also added `__pycache__/` and `*.pyc` to `.gitignore`.

## Testing

Verified against a local mock HTTP server (stdlib `http.server`):

- ✅ Sonarr multi-episode (`"101, 102 ,103"`) → `PUT /api/v3/episode/monitor` body `{"episodeIds":[101,102,103],"monitored":false}`, exit 0.
- ✅ Radarr → `GET` then `PUT /api/v3/movie/1254?moveFiles=false` with `monitored:false`, logs `MovieID:1254`, exit 0.
- ✅ Test event validates API key, host, and port (exit 0 when set; exit 1 with clear stderr when host missing).
- ✅ Unreachable host exits 1 with a descriptive error.
- ✅ Both scripts `py_compile` clean and run under stdlib-only Python 3.

> Note: live end-to-end testing requires running Radarr/Sonarr instances, which weren't available in the dev environment; validation was done via a mock of the HTTP endpoints asserting the request URL, method, and body.

Closes #7, #8, #9, #10, #11, #12, #13

https://claude.ai/code/session_01SYggoBGRbndbfPrcDD4Rxn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYggoBGRbndbfPrcDD4Rxn)_